### PR TITLE
Code style fixes

### DIFF
--- a/src/main/resources/script_templates/Deconvolution/DeconWithChirpImg.groovy
+++ b/src/main/resources/script_templates/Deconvolution/DeconWithChirpImg.groovy
@@ -1,7 +1,7 @@
-// @OpService ops
-// @UIService ui
-// @ConvertService convert
-// @DatasetService data
+#@ OpService ops
+#@ UIService ui
+#@ ConvertService convert
+#@ DatasetService data
 
 // Author Daniel James White/Brian Northan
 // Prerequisite install http://www.optinav.info/Diffraction-PSF-3D.htm

--- a/src/main/resources/script_templates/Deconvolution/DeconWithGaussian.py
+++ b/src/main/resources/script_templates/Deconvolution/DeconWithGaussian.py
@@ -14,7 +14,7 @@ if img_float.numDimensions()==3:
 	psf=ops.create().kernelGauss([sxy, sxy, sz])
 elif img_float.numDimensions()==2:
 	psf=ops.create().kernelGauss([sxy, sxy])
-		
+
 ui.show(psf)
 
 # deconvolve

--- a/src/main/resources/script_templates/Deconvolution/DeconWithGaussian.py
+++ b/src/main/resources/script_templates/Deconvolution/DeconWithGaussian.py
@@ -1,10 +1,10 @@
-# @OpService ops
-# @UIService ui
-# @ImgPlus img
-# @Integer sxy
-# @Integer sz
-# @Integer numIterations
-# @OUTPUT ImgPlus deconvolved
+#@ OpService ops
+#@ UIService ui
+#@ ImgPlus img
+#@ Integer sxy
+#@ Integer sz
+#@ Integer numIterations
+#@OUTPUT ImgPlus deconvolved
 
 # convert to float (TODO: make sure deconvolution op works on other types)
 img_float=ops.convert().float32(img)

--- a/src/main/resources/script_templates/Deconvolution/DeconWithGrid.groovy
+++ b/src/main/resources/script_templates/Deconvolution/DeconWithGrid.groovy
@@ -1,7 +1,7 @@
-// @OpService ops
-// @UIService ui
-// @ConvertService convert
-// @DatasetService data
+#@ OpService ops
+#@ UIService ui
+#@ ConvertService convert
+#@ DatasetService data
 
 import net.imglib2.type.numeric.real.FloatType;
 import net.imagej.ops.Op

--- a/src/main/resources/script_templates/Deconvolution/DeconWithTheoreticalPSF.py
+++ b/src/main/resources/script_templates/Deconvolution/DeconWithTheoreticalPSF.py
@@ -1,15 +1,15 @@
-# @OpService ops
-# @UIService ui
-# @ImgPlus img
-# @Integer numIterations(value=30)
-# @Float numericalAperture(value=1.4)
-# @Float wavelength(value=550)
-# @Float riImmersion(value=1.5)
-# @Float riSample(value=1.4)
-# @Float xySpacing(value=62.9)
-# @Float zSpacing(value=160)
-# @OUTPUT ImgPlus psf
-# @OUTPUT ImgPlus deconvolved
+#@ OpService ops
+#@ UIService ui
+#@ ImgPlus img
+#@ Integer numIterations(value=30)
+#@ Float numericalAperture(value=1.4)
+#@ Float wavelength(value=550)
+#@ Float riImmersion(value=1.5)
+#@ Float riSample(value=1.4)
+#@ Float xySpacing(value=62.9)
+#@ Float zSpacing(value=160)
+#@OUTPUT ImgPlus psf
+#@OUTPUT ImgPlus deconvolved
 
 from net.imglib2 import FinalDimensions
 from net.imglib2.type.numeric.real import FloatType;

--- a/src/main/resources/script_templates/Deconvolution/ExtractPSF.py
+++ b/src/main/resources/script_templates/Deconvolution/ExtractPSF.py
@@ -1,8 +1,8 @@
-# @OpService ops
-# @ImgPlus beads
-# @OUTPUT ImgPlus thresholded
-# @OUTPUT ImgPlus points
-# @OUTPUT ImgPlus psf
+#@ OpService ops
+#@ ImgPlus beads
+#@OUTPUT ImgPlus thresholded
+#@OUTPUT ImgPlus points
+#@OUTPUT ImgPlus psf
 
 from net.imglib2.algorithm.labeling.ConnectedComponents import StructuringElement
 from net.imglib2.roi import Regions;

--- a/src/main/resources/script_templates/Deconvolution/ExtractPSF.py
+++ b/src/main/resources/script_templates/Deconvolution/ExtractPSF.py
@@ -5,10 +5,7 @@
 #@OUTPUT ImgPlus psf
 
 from net.imglib2.algorithm.labeling.ConnectedComponents import StructuringElement
-from net.imglib2.roi import Regions;
-from net.imglib2.roi.labeling import LabelRegions;
-
-from java.util import ArrayList;
+from net.imglib2.roi.labeling import LabelRegions
 
 # reference
 # (note. there used to be good references on the Huygens web site, but that seems only accessible by password now)
@@ -17,22 +14,22 @@ from java.util import ArrayList;
 # assumptions
 # 1. assuming a 3D (x,yz) dataset
 # 2. assuming the image contains sub-resolution beads
-#    note.  It is expected some beads may "clump" into larger objects, 
-#    the script may still work under these conditions, but the cleaner the 
+#    note.  It is expected some beads may "clump" into larger objects,
+#    the script may still work under these conditions, but the cleaner the
 #    the bead image the better the PSF.
 # 3. We use integer locations for bead centroids.  In reality beads are centered
 #    at sub-resolution locations.  However as long as we have enough beads the error
-#    in position should "even out". 
+#    in position should "even out".
 
 # get dimensions of bead image
-xSize=beads.dimension(0);
-ySize=beads.dimension(1);
-zSize=beads.dimension(2);
+xSize=beads.dimension(0)
+ySize=beads.dimension(1)
+zSize=beads.dimension(2)
 
 # create an empty image to store the points
 points=ops.create().img([xSize, ySize, zSize])
 
-# otsu threshold to find the beads 
+# otsu threshold to find the beads
 thresholded = ops.threshold().otsu(beads)
 
 # call connected components to label each connected region
@@ -45,9 +42,9 @@ labelingIndex=labeling.getIndexImg()
 regions=LabelRegions(labeling)
 
 for region in regions:
-	
-	# get the center of mass of the region 
-	center=region.getCenterOfMass();
+
+	# get the center of mass of the region
+	center=region.getCenterOfMass()
 
 	# place a point at the bead centroid
 	randomAccess= points.randomAccess()
@@ -55,8 +52,8 @@ for region in regions:
 	randomAccess.get().setReal(255.0)
 
 # convert images to float
-beads32=ops.convert().float32(beads);
-points32=ops.convert().float32(points);
+beads32=ops.convert().float32(beads)
+points32=ops.convert().float32(points)
 
 # use "PSF Distilling" (reverse deconvolution) to solve for PSF
 psf=ops.deconvolve().richardsonLucy(beads32, points32, None, None, None, None, None, 30, False, True)

--- a/src/main/resources/script_templates/Deconvolution/PreprocessPsfDeconvolve.py
+++ b/src/main/resources/script_templates/Deconvolution/PreprocessPsfDeconvolve.py
@@ -9,8 +9,8 @@
 #@OUTPUT ImgPlus psf_
 #@OUTPUT ImgPlus deconvolved_
 
-# deconvolve an image, the key thing in this script is that the PSF is preprocessed so 
-# we get faster and better results. 
+# deconvolve an image, the key thing in this script is that the PSF is preprocessed so
+# we get faster and better results.
 # 1.  Crop PSF (smaller PSF -> faster results (assuming we extend image to avoid wrap around)
 # 2.  Normalize PSF (required to keep sum of image signal constant)
 # 3.  Subtract background from PSF (small background values can reduce deconvolution quality)
@@ -18,8 +18,6 @@
 from net.imglib2.util import Intervals
 from net.imagej.axis import Axes
 from net.imglib2.type.numeric.real import FloatType
-
-from java.lang.Math import floor
 
 # crop PSF to desired size, this makes decon run faster with little effect on final quality
 psfX = psf.dimension(data.dimensionIndex(Axes.X))
@@ -52,5 +50,5 @@ psf_=ops.math().divide(psf_, sumpsf);
 # convert image to 32 bit
 img_=ops.convert().float32(data.getImgPlus());
 
-# now deconvolve 
+# now deconvolve
 deconvolved_=ops.deconvolve().richardsonLucy(img_, psf_, None, None, None, None, None, 30, nonCirculant, acceleration)

--- a/src/main/resources/script_templates/Deconvolution/PreprocessPsfDeconvolve.py
+++ b/src/main/resources/script_templates/Deconvolution/PreprocessPsfDeconvolve.py
@@ -1,13 +1,13 @@
-# @OpService ops
-# @Dataset data
-# @Dataset psf
-# @Integer(value=128) psfXSize
-# @Integer(value=128) psfYSize
-# @Float(value=0.01) psfBackgroundPercent
-# @Boolean(value=True) nonCirculant
-# @Boolean(value=True) acceleration
-# @OUTPUT ImgPlus psf_
-# @OUTPUT ImgPlus deconvolved_
+#@ OpService ops
+#@ Dataset data
+#@ Dataset psf
+#@ Integer(value=128) psfXSize
+#@ Integer(value=128) psfYSize
+#@ Float(value=0.01) psfBackgroundPercent
+#@ Boolean(value=True) nonCirculant
+#@ Boolean(value=True) acceleration
+#@OUTPUT ImgPlus psf_
+#@OUTPUT ImgPlus deconvolved_
 
 # deconvolve an image, the key thing in this script is that the PSF is preprocessed so 
 # we get faster and better results. 

--- a/src/main/resources/script_templates/Filters/Blur_Image.scala
+++ b/src/main/resources/script_templates/Filters/Blur_Image.scala
@@ -1,6 +1,6 @@
-// @Dataset inputImg
-// @OpService ops
-// @OUTPUT Dataset(label="Blurred") blurredImg
+#@ Dataset inputImg
+#@ OpService ops
+#@OUTPUT Dataset(label="Blurred") blurredImg
 
 // A simple Scala script that blurs an input image with
 // a Gaussian filter. Note that you must have an image

--- a/src/main/resources/script_templates/Filters/Lowpass.groovy
+++ b/src/main/resources/script_templates/Filters/Lowpass.groovy
@@ -1,8 +1,8 @@
-// @OpService ops
-// @UIService ui
-// @ImgPlus img
-// @Integer radius
-// @OUTPUT ImgPlus filtered
+#@ OpService ops
+#@ UIService ui
+#@ ImgPlus img
+#@ Integer radius
+#@OUTPUT ImgPlus filtered
 
 import net.imglib2.img.display.imagej.ImageJFunctions
 import net.imglib2.util.Util

--- a/src/main/resources/script_templates/ImageJ2/Apply_DOG_Filtering.py
+++ b/src/main/resources/script_templates/ImageJ2/Apply_DOG_Filtering.py
@@ -12,20 +12,20 @@ from net.imagej.axis import Axes
 
 # Convert data to float 32
 converted = ops.convert().float32(data.getImgPlus())
- 
+
 # Allocate output memory (wait for hybrid CF version of slice)
 dog = ops.create().img(converted)
- 
+
 # Create the op
 dog_op = ops.op("filter.dog", converted, sigma1, sigma2)
- 
+
 # Setup the fixed axis
 t_dim = data.dimensionIndex(Axes.TIME)
 fixed_axis = [d for d in range(0, data.numDimensions()) if d != t_dim]
- 
+
 # Run the op
 ops.slice(dog, converted, dog_op, fixed_axis)
- 
+
 # Clip image to the input type
 clipped = ops.create().img(dog, data.getImgPlus().firstElement())
 clip_op = ops.op("convert.clip", data.getImgPlus().firstElement(), dog.firstElement())

--- a/src/main/resources/script_templates/ImageJ2/Apply_DOG_Filtering.py
+++ b/src/main/resources/script_templates/ImageJ2/Apply_DOG_Filtering.py
@@ -1,9 +1,9 @@
-# @Dataset data
-# @Float(label="Sigma 1 (pixel)", required=true, value=4.2, stepSize=0.1) sigma1
-# @Float(label="Sigma 2 (pixel)", required=true, value=1.25, stepSize=0.1) sigma2
-# @OUTPUT Dataset output
-# @OpService ops
-# @DatasetService ds
+#@ Dataset data
+#@ Float(label="Sigma 1 (pixel)", required=true, value=4.2, stepSize=0.1) sigma1
+#@ Float(label="Sigma 2 (pixel)", required=true, value=1.25, stepSize=0.1) sigma2
+#@OUTPUT Dataset output
+#@ OpService ops
+#@ DatasetService ds
 
 # Run a DOG filter on all the frames along the TIME axis.
 # After the filtering step the image is clipped to match the input type.

--- a/src/main/resources/script_templates/ImageJ2/Apply_Mask.py
+++ b/src/main/resources/script_templates/ImageJ2/Apply_Mask.py
@@ -1,6 +1,6 @@
-# @Dataset data
-# @Dataset mask
-# @OUTPUT Dataset output
+#@ Dataset data
+#@ Dataset mask
+#@OUTPUT Dataset output
 
 # Given a mask (binary image) and a raw image, remove background pixel from raw by
 # keeping only those in the mask (different from 0).

--- a/src/main/resources/script_templates/ImageJ2/Apply_Mask.py
+++ b/src/main/resources/script_templates/ImageJ2/Apply_Mask.py
@@ -17,7 +17,7 @@ if not Intervals.equalDimensions(data, mask):
     raise Exception("Dimensions from input dataset does not match.")
 
 # Create the cursors
-output = data.duplicate() 
+output = data.duplicate()
 targetCursor = output.localizingCursor()
 dataRA = data.randomAccess()
 maskRA = mask.randomAccess()
@@ -27,7 +27,7 @@ while targetCursor.hasNext():
     targetCursor.fwd()
     dataRA.setPosition(targetCursor)
     maskRA.setPosition(targetCursor)
- 
+
     if maskRA.get().get() == 0:
         targetCursor.get().set(0)
     else:

--- a/src/main/resources/script_templates/ImageJ2/Apply_Threshold.py
+++ b/src/main/resources/script_templates/ImageJ2/Apply_Threshold.py
@@ -1,9 +1,9 @@
-# @String(label="Threshold Method", required=true, choices={'otsu', 'huang'}) method_threshold
-# @Float(label="Relative threshold", required=true, value=1, stepSize=0.1) relative_threshold
-# @Dataset data
-# @OUTPUT Dataset output
-# @OpService ops
-# @DatasetService ds
+#@ String(label="Threshold Method", required=true, choices={'otsu', 'huang'}) method_threshold
+#@ Float(label="Relative threshold", required=true, value=1, stepSize=0.1) relative_threshold
+#@ Dataset data
+#@OUTPUT Dataset output
+#@ OpService ops
+#@ DatasetService ds
 
 # Apply an automatic threshold from a given method. The threshold value 'threshold_value'
 # can be modulated by a relative parameter called 'relative_threshold' (if equal to 1 it does

--- a/src/main/resources/script_templates/ImageJ2/Apply_Threshold_Fast.py
+++ b/src/main/resources/script_templates/ImageJ2/Apply_Threshold_Fast.py
@@ -1,8 +1,8 @@
-# @String(label="Threshold Method", required=true, choices={'otsu', 'huang'}) method_threshold
-# @Dataset data
-# @OUTPUT Dataset output
-# @OpService ops
-# @DatasetService ds
+#@ String(label="Threshold Method", required=true, choices={'otsu', 'huang'}) method_threshold
+#@ Dataset data
+#@OUTPUT Dataset output
+#@ OpService ops
+#@ DatasetService ds
 
 # Apply an automatic threshold from a given method.
 thresholded = ops.run("threshold.%s" % method_threshold, data)

--- a/src/main/resources/script_templates/ImageJ2/Crop.py
+++ b/src/main/resources/script_templates/ImageJ2/Crop.py
@@ -1,7 +1,7 @@
-# @Dataset data
-# @OUTPUT Dataset output
-# @DatasetService ds
-# @OpService ops
+#@ Dataset data
+#@OUTPUT Dataset output
+#@ DatasetService ds
+#@ OpService ops
 
 from net.imagej.axis import Axes
 from net.imglib2.util import Intervals

--- a/src/main/resources/script_templates/ImageJ2/Crop.py
+++ b/src/main/resources/script_templates/ImageJ2/Crop.py
@@ -7,7 +7,7 @@ from net.imagej.axis import Axes
 from net.imglib2.util import Intervals
 
 # This function helps to crop a Dataset along an arbitrary number of Axes.
-# Intervals to crop are specified easily as a Python dict. 
+# Intervals to crop are specified easily as a Python dict.
 
 
 def get_axis(axis_type):
@@ -19,10 +19,9 @@ def get_axis(axis_type):
         'CHANNEL': Axes.CHANNEL,
     }.get(axis_type, Axes.Z)
 
- 
 def crop(ops, data, intervals):
     """Crop along a one or more axis.
- 
+
     Parameters
     ----------
     intervals : Dict specifying which axis to crop and with what intervals.
@@ -30,19 +29,19 @@ def crop(ops, data, intervals):
                 intervals = {'X' : [0, 50],
                              'Y' : [0, 50]}
     """
- 
+
     intervals_start = [data.min(d) for d in range(0, data.numDimensions())]
     intervals_end = [data.max(d) for d in range(0, data.numDimensions())]
- 
+
     for axis_type, interval in intervals.items():
         index = data.dimensionIndex(get_axis(axis_type))
         intervals_start[index] = interval[0]
         intervals_end[index] = interval[1]
- 
+
     intervals = Intervals.createMinMax(*intervals_start + intervals_end)
- 
+
     output = ops.run("transform.crop", data, intervals, True)
-    
+
     return output
 
 

--- a/src/main/resources/script_templates/ImageJ2/Manual_Registration.py
+++ b/src/main/resources/script_templates/ImageJ2/Manual_Registration.py
@@ -1,8 +1,8 @@
-# @Dataset ds
-# @OUTPUT Dataset output
-# @OpService ops
-# @LogService log
-# @DatasetService datasetService
+#@ Dataset ds
+#@OUTPUT Dataset output
+#@ OpService ops
+#@ LogService log
+#@ DatasetService datasetService
 
 # This script translates individual slices in a stack according to single
 # point ROIs (defined in the IJ1 ROIManager). If slices exist in between specified ROIs,

--- a/src/main/resources/script_templates/ImageJ2/Particles_From_Mask.py
+++ b/src/main/resources/script_templates/ImageJ2/Particles_From_Mask.py
@@ -5,7 +5,7 @@
 # This script identify all the particles from a mask and create label regions over which you can iterate.
 # The second part of the script display all the detected regions into the IJ1 RoiManager.
 
- 
+
 from ij.gui import PointRoi
 from ij.plugin.frame import RoiManager
 from net.imglib2.algorithm.labeling.ConnectedComponents import StructuringElement
@@ -28,41 +28,41 @@ labeled_img = ij.op().run("cca", img, StructuringElement.EIGHT_CONNECTED)
 # Create label regions from particles
 regions = LabelRegions(labeled_img)
 region_labels = list(regions.getExistingLabels())
- 
+
 print("%i regions/particles detected" % len(region_labels))
- 
-# Now use IJ1 RoiManager to display the detected regions 
+
+# Now use IJ1 RoiManager to display the detected regions
 rm = get_roi_manager(new=True)
 
 for label in region_labels:
-  
+
     region = regions.getLabelRegion(label)
 
   	# Get the center of mass of the region
     center = region.getCenterOfMass()
     x = center.getDoublePosition(0)
     y = center.getDoublePosition(1)
-  
+
     roi = PointRoi(x, y)
     if center.numDimensions() >= 3:
         z = center.getDoublePosition(2)
         roi.setPosition(int(z))
-      
+
     rm.addRoi(roi)
- 
+
     # You can also iterate over the `data` pixel by LabelRegion
- 
+
     cursor = region.localizingCursor()
     dataRA = data.randomAccess()
     while cursor.hasNext():
         cursor.fwd()
         dataRA.setPosition(cursor)
-     
+
         x = cursor.getDoublePosition(0)
         y = cursor.getDoublePosition(1)
- 
+
         # Pixel of `data`
         pixel = dataRA.get()
- 
+
         # Do whatever you want here
         # print(x, y, pixel)

--- a/src/main/resources/script_templates/ImageJ2/Particles_From_Mask.py
+++ b/src/main/resources/script_templates/ImageJ2/Particles_From_Mask.py
@@ -1,6 +1,6 @@
-# @ImageJ ij
-# @Dataset data
-# @Dataset mask
+#@ ImageJ ij
+#@ Dataset data
+#@ Dataset mask
 
 # This script identify all the particles from a mask and create label regions over which you can iterate.
 # The second part of the script display all the detected regions into the IJ1 RoiManager.

--- a/src/main/resources/script_templates/ImageJ2/Projection.py
+++ b/src/main/resources/script_templates/ImageJ2/Projection.py
@@ -7,7 +7,7 @@
 
 # Do a projection of a stack. The projection is done along a specified axis.
 # The commin use case of this script is to do a maximum Z projection.
- 
+
 from net.imagej.axis import Axes
 from net.imagej.ops import Ops
 

--- a/src/main/resources/script_templates/ImageJ2/Projection.py
+++ b/src/main/resources/script_templates/ImageJ2/Projection.py
@@ -1,9 +1,9 @@
-# @Dataset data
-# @String(label="Dimension to Project", choices={"X", "Y", "Z", "TIME", "CHANNEL"}) projected_dimension
-# @String(label="Projection Type", choices={"Max","Mean","Median","Min", "StdDev", "Sum"}) projection_type
-# @OUTPUT Dataset output
-# @OpService ops
-# @DatasetService ds
+#@ Dataset data
+#@ String(label="Dimension to Project", choices={"X", "Y", "Z", "TIME", "CHANNEL"}) projected_dimension
+#@ String(label="Projection Type", choices={"Max","Mean","Median","Min", "StdDev", "Sum"}) projection_type
+#@OUTPUT Dataset output
+#@ OpService ops
+#@ DatasetService ds
 
 # Do a projection of a stack. The projection is done along a specified axis.
 # The commin use case of this script is to do a maximum Z projection.

--- a/src/main/resources/script_templates/ImageJ2/Rotate_Stack.py
+++ b/src/main/resources/script_templates/ImageJ2/Rotate_Stack.py
@@ -1,8 +1,8 @@
-# @Float(label="Rotation angle (in degree)", required=true, value=90, stepSize=0.1) angle
-# @Dataset data
-# @OUTPUT Dataset output
-# @OpService ops
-# @DatasetService ds
+#@ Float(label="Rotation angle (in degree)", required=true, value=90, stepSize=0.1) angle
+#@ Dataset data
+#@OUTPUT Dataset output
+#@ OpService ops
+#@ DatasetService ds
 
 # This script rotates all the frame of a stack along the TIME axis to a given angle.
 # I found this script over complicated for what it is supposed to do. I hope a simpler way to do this kind of 

--- a/src/main/resources/script_templates/ImageJ2/Rotate_Stack.py
+++ b/src/main/resources/script_templates/ImageJ2/Rotate_Stack.py
@@ -5,7 +5,7 @@
 #@ DatasetService ds
 
 # This script rotates all the frame of a stack along the TIME axis to a given angle.
-# I found this script over complicated for what it is supposed to do. I hope a simpler way to do this kind of 
+# I found this script over complicated for what it is supposed to do. I hope a simpler way to do this kind of
 # transformation will be avaiable one day. At that time the script would have to be updated.
 
 import math
@@ -16,7 +16,7 @@ from net.imglib2.realtransform import RealViews
 from net.imglib2.util import Intervals
 from net.imglib2.view import Views
 
- 
+
 def get_axis(axis_type):
     return {
         'X': Axes.X,
@@ -25,64 +25,64 @@ def get_axis(axis_type):
         'TIME': Axes.TIME,
         'CHANNEL': Axes.CHANNEL,
     }.get(axis_type, Axes.Z)
-     
- 
+
+
 def crop_along_one_axis(ops, data, intervals, axis_type):
     """Crop along a single axis using Views.
- 
+
     Parameters
     ----------
     intervals : List with two values specifying the start and the end of the interval.
     axis_type : Along which axis to crop. Can be ["X", "Y", "Z", "TIME", "CHANNEL"]
     """
- 
+
     axis = get_axis(axis_type)
     interval_start = [data.min(d) if d != data.dimensionIndex(axis) else intervals[0] for d in range(0, data.numDimensions())]
     interval_end = [data.max(d) if d != data.dimensionIndex(axis) else intervals[1] for d in range(0, data.numDimensions())]
- 
+
     interval = interval_start + interval_end
     interval = Intervals.createMinMax(*interval)
- 
+
     output = ops.run("transform.crop", data, interval, True)
- 
+
     return output
-    
- 
+
+
 # Get the center of the images so we do the rotation according to it
 center = [int(round((data.max(d) / 2 + 1))) for d in range(2)]
- 
+
 # Convert angles to radians
 angle_rad = angle * math.pi / 180
- 
+
 # Build the affine transformation
 affine = AffineTransform2D()
 affine.translate([-p for p in center])
 affine.rotate(angle_rad)
 affine.translate(center)
- 
+
 # Get the interpolator
 interpolator = LanczosInterpolatorFactory()
- 
+
 # Iterate over all frame in the stack
 axis = Axes.TIME
 output = []
 for d in range(data.dimension(axis)):
- 
+
     # Get the current frame
     frame = crop_along_one_axis(ops, data, [d, d], "TIME")
- 
+
     # Get the interpolate view of the frame
     extended = ops.run("transform.extendZeroView", frame)
     interpolant = ops.run("transform.interpolateView", extended, interpolator)
- 
+
     # Apply the transformation to it
     rotated = RealViews.affine(interpolant, affine)
-     
+
     # Set the intervals
     rotated = ops.transform().offsetView(rotated, frame)
- 
+
     output.append(rotated)
- 
+
 output = Views.stack(output)
 
 # Create output Dataset

--- a/src/main/resources/script_templates/ImageJ2/Stack_Directory_Images.py
+++ b/src/main/resources/script_templates/ImageJ2/Stack_Directory_Images.py
@@ -1,10 +1,10 @@
-# @File(label="Directory of the images sequence", style="directory") images_sequence_dir
-# @String(label="Image File Extension", required=false, value=".tif") image_extension
-# @String(label="Type of Axis for the stack", required=false, value="TIME", choices={"TIME", "Z", "CHANNEL"}) axis_type
-# @OUTPUT Dataset output
+#@ File(label="Directory of the images sequence", style="directory") images_sequence_dir
+#@ String(label="Image File Extension", required=false, value=".tif") image_extension
+#@ String(label="Type of Axis for the stack", required=false, value="TIME", choices={"TIME", "Z", "CHANNEL"}) axis_type
+#@OUTPUT Dataset output
 
-# @DatasetService ds
-# @DatasetIOService io
+#@ DatasetService ds
+#@ DatasetIOService io
 
 # This script takes a directory as a parameter, find all the files ending with ".tif" in the directory.
 # Sort them and stack them to create a 3D dataset.

--- a/src/main/resources/script_templates/ImageJ2/Subtract_First_Image_Stack.py
+++ b/src/main/resources/script_templates/ImageJ2/Subtract_First_Image_Stack.py
@@ -1,7 +1,7 @@
-# @Dataset data
-# @OUTPUT Dataset output
-# @OpService ops
-# @DatasetService ds
+#@ Dataset data
+#@OUTPUT Dataset output
+#@ OpService ops
+#@ DatasetService ds
 
 # Subtract the first frame of a stack to all the frames of the given stack along the TIME axis.
 # It removes the static elements from a stack. Usefull when you are studying moving objects.

--- a/src/main/resources/script_templates/ImageJ2/Subtract_First_Image_Stack.py
+++ b/src/main/resources/script_templates/ImageJ2/Subtract_First_Image_Stack.py
@@ -5,13 +5,13 @@
 
 # Subtract the first frame of a stack to all the frames of the given stack along the TIME axis.
 # It removes the static elements from a stack. Usefull when you are studying moving objects.
- 
+
 from net.imglib2.util import Intervals
 from net.imagej.axis import Axes
- 
+
 # Convert input
 converted = ops.convert().float32(data)
- 
+
 # Get the first frame (TODO: find a more convenient way !)
 t_dim = data.dimensionIndex(Axes.TIME)
 interval_start = []
@@ -23,24 +23,24 @@ for d in range(0, data.numDimensions()):
     else:
         interval_start.append(0)
         interval_end.append(0)
-         
+
 intervals = interval_start + interval_end
 intervals = Intervals.createMinMax(*intervals)
- 
+
 first_frame = ops.transform().crop(converted, intervals)
- 
+
 # Allocate output memory (wait for hybrid CF version of slice)
 subtracted = ops.create().img(converted)
- 
+
 # Create the op
 sub_op =  ops.op("math.subtract", first_frame, first_frame)
- 
+
 # Setup the fixed axis
 fixed_axis = [d for d in range(0, data.numDimensions()) if d != t_dim]
- 
+
 # Run the op
 ops.slice(subtracted, converted, sub_op, fixed_axis)
- 
+
 # Clip image to the input type
 clipped = ops.create().img(subtracted, data.getImgPlus().firstElement())
 clip_op = ops.op("convert.clip", data.getImgPlus().firstElement(), subtracted.firstElement())

--- a/src/main/resources/script_templates/Tutorials/01_-_Intro_to_ImageJ_API.groovy
+++ b/src/main/resources/script_templates/Tutorials/01_-_Intro_to_ImageJ_API.groovy
@@ -1,8 +1,8 @@
-// @PluginService plugin
-// @LogService log
-// @StatusService status
-// @MenuService menu
-// @PlatformService platform
+#@ PluginService plugin
+#@ LogService log
+#@ StatusService status
+#@ MenuService menu
+#@ PlatformService platform
 
 // Here are some examples of the API in action:
 

--- a/src/main/resources/script_templates/Tutorials/02_-_Load_and_Display_Dataset.py
+++ b/src/main/resources/script_templates/Tutorials/02_-_Load_and_Display_Dataset.py
@@ -1,6 +1,6 @@
-# @DatasetIOService ds
-# @UIService ui
-# @File file
+#@ DatasetIOService ds
+#@ UIService ui
+#@ File file
 
 # load the dataset
 dataset = ds.open(file.getAbsolutePath())

--- a/src/main/resources/script_templates/Tutorials/03_-_Using_Ops.groovy
+++ b/src/main/resources/script_templates/Tutorials/03_-_Using_Ops.groovy
@@ -1,7 +1,7 @@
-// @OpService ops
-// @CommandService cmd
-// @LogService log
-// @UIService ui
+#@ OpService ops
+#@ CommandService cmd
+#@ LogService log
+#@ UIService ui
 
 import net.imagej.ops.Op
 import net.imglib2.FinalDimensions

--- a/src/main/resources/script_templates/Tutorials/Create_and_Convolve_Points.py
+++ b/src/main/resources/script_templates/Tutorials/Create_and_Convolve_Points.py
@@ -1,9 +1,9 @@
-# @OpService ops
-# @int(value=128) xSize
-# @int(value=128) ySize
-# @int(value=128) zSize
-# @OUTPUT ImgPlus phantom
-# @OUTPUT ImgPlus convolved
+#@ OpService ops
+#@ Integer (value=128) xSize
+#@ Integer (value=128) ySize
+#@ Integer (value=128) zSize
+#@OUTPUT ImgPlus phantom
+#@OUTPUT ImgPlus convolved
 
 from net.imglib2 import Point
 

--- a/src/main/resources/script_templates/Tutorials/Crop_Confocal_Series.py
+++ b/src/main/resources/script_templates/Tutorials/Crop_Confocal_Series.py
@@ -1,9 +1,9 @@
-# @OpService ops
-# @Dataset data
-# @OUTPUT ImgPlus c0
-# @OUTPUT ImgPlus z12
-# @OUTPUT ImgPlus c0z12
-# @OUTPUT ImgPlus roiC0z12
+#@ OpService ops
+#@ Dataset data
+#@OUTPUT ImgPlus c0
+#@OUTPUT ImgPlus z12
+#@OUTPUT ImgPlus c0z12
+#@OUTPUT ImgPlus roiC0z12
 
 # to run this tutorial run 'file->Open Samples->Confocal Series' and make sure that
 # confocal-series.tif is the active image

--- a/src/main/resources/script_templates/Tutorials/Find_Template.py
+++ b/src/main/resources/script_templates/Tutorials/Find_Template.py
@@ -1,7 +1,7 @@
-# @OpService ops
-# @UIService ui
-# @ImgPlus image
-# @ImgPlus template
+#@ OpService ops
+#@ UIService ui
+#@ ImgPlus image
+#@ ImgPlus template
 
 # Run this tutorial using the C0Z12 and roiC0Z12 images generated in the 'Crop Confocal Series' tutorial.
 

--- a/src/main/resources/script_templates/Tutorials/Find_Template.py
+++ b/src/main/resources/script_templates/Tutorials/Find_Template.py
@@ -44,7 +44,7 @@ ImageJFunctions.show( templateFFT,ComplexPhaseFloatConverter() ).setTitle( "fft 
 
 # display fft real values
 ImageJFunctions.show( templateFFT,ComplexRealFloatConverter() ).setTitle( "fft real values" )
-        
+
 # display fft imaginary values
 ImageJFunctions.show( templateFFT, ComplexImaginaryFloatConverter() ).setTitle( "fft imaginary values" )
 
@@ -56,7 +56,7 @@ for  t in templateFFT:
 	c.mul(t)
 	t.div(c)
 
-# create Img memory for inverse FFT and compute inverse 
+# create Img memory for inverse FFT and compute inverse
 templateInverse=ops.create().img([template.dimension(0), template.dimension(1)])
 
 ops.filter().ifft(templateInverse, templateFFT)
@@ -65,4 +65,3 @@ ui.show("template inverse", templateInverse)
 # convolve templateInverse with image
 final=ops.filter().convolve(image, templateInverse)
 ui.show("final", final)
-	

--- a/src/main/resources/script_templates/Tutorials/Ops_Threshold_IJ1_Analyze.py
+++ b/src/main/resources/script_templates/Tutorials/Ops_Threshold_IJ1_Analyze.py
@@ -1,8 +1,8 @@
-# @OpService ops
-# @ImgPlus inputData
-# @Double sigma
-# @OUTPUT ImgPlus logFiltered
-# @OUTPUT ImgPlus thresholded
+#@ OpService ops
+#@ ImgPlus inputData
+#@ Double sigma
+#@OUTPUT ImgPlus logFiltered
+#@OUTPUT ImgPlus thresholded
 
 # Run this tutorial using the C0Z12 image generated in the 'Crop Confocal Series' tutorial.
 

--- a/src/main/resources/script_templates/Tutorials/Ops_Threshold_IJ1_Analyze.py
+++ b/src/main/resources/script_templates/Tutorials/Ops_Threshold_IJ1_Analyze.py
@@ -7,12 +7,11 @@
 # Run this tutorial using the C0Z12 image generated in the 'Crop Confocal Series' tutorial.
 
 # To generate the C0Z12 image, do the following:
-# Go to 'file>Open Samples>Confocal Series' and make sure confocal-series.tif is the active image and 
+# Go to 'file>Open Samples>Confocal Series' and make sure confocal-series.tif is the active image and
 # run the Crop Confocal Series tutorial.
 
 from net.imglib2.img.display.imagej import ImageJFunctions
 from ij import IJ
-from java.lang import Integer
 
 # create a log kernel
 logKernel=ops.create().kernelLog(inputData.numDimensions(), sigma);

--- a/src/main/resources/script_templates/Tutorials/Ops_Threshold_Measure.py
+++ b/src/main/resources/script_templates/Tutorials/Ops_Threshold_Measure.py
@@ -8,7 +8,7 @@
 # Run this tutorial using the C0Z12 image generated in the 'Crop Confocal Series' tutorial.
 
 # To generate the C0Z12 image, do the following:
-# Go to 'file>Open Samples>Confocal Series' and make sure confocal-series.tif is the active image and 
+# Go to 'file>Open Samples>Confocal Series' and make sure confocal-series.tif is the active image and
 # run the Crop Confocal Series tutorial.
 
 from net.imglib2.algorithm.labeling.ConnectedComponents import StructuringElement
@@ -39,5 +39,3 @@ for region in regions:
 	intensity=ops.stats().mean(Regions.sample(region, inputData)).getRealDouble()
 
 	print "size",size,"intensity",intensity
-	
-	

--- a/src/main/resources/script_templates/Tutorials/Ops_Threshold_Measure.py
+++ b/src/main/resources/script_templates/Tutorials/Ops_Threshold_Measure.py
@@ -1,9 +1,9 @@
-# @OpService ops
-# @ImgPlus inputData
-# @Double sigma
-# @OUTPUT ImgPlus logFiltered
-# @OUTPUT ImgPlus thresholded
-# @OUTPUT ImgPlus labelingIndex
+#@ OpService ops
+#@ ImgPlus inputData
+#@ Double sigma
+#@OUTPUT ImgPlus logFiltered
+#@OUTPUT ImgPlus thresholded
+#@OUTPUT ImgPlus labelingIndex
 
 # Run this tutorial using the C0Z12 image generated in the 'Crop Confocal Series' tutorial.
 

--- a/src/main/resources/script_templates/Tutorials/Projections.py
+++ b/src/main/resources/script_templates/Tutorials/Projections.py
@@ -1,8 +1,8 @@
-# @OpService ops
-# @UIService ui
-# @Dataset data
-# @OUTPUT ImgPlus maxProjection
-# @OUTPUT ImgPlus sumProjection
+#@ OpService ops
+#@ UIService ui
+#@ Dataset data
+#@OUTPUT ImgPlus maxProjection
+#@OUTPUT ImgPlus sumProjection
 
 
 # Run this tutorial using the C0 image generated in the 'Crop Confocal Series' tutorial.

--- a/src/main/resources/script_templates/Tutorials/Simple_Convolution.groovy
+++ b/src/main/resources/script_templates/Tutorials/Simple_Convolution.groovy
@@ -1,5 +1,5 @@
-#@OpService ops
-#@ImgPlus inputData
+#@ OpService ops
+#@ ImgPlus inputData
 #@OUTPUT ImgPlus(label="Filtered") filtered
 #@OUTPUT ImgPlus(label="Convolved") result
 

--- a/src/main/resources/script_templates/Tutorials/Slicewise_Threshold.py
+++ b/src/main/resources/script_templates/Tutorials/Slicewise_Threshold.py
@@ -1,6 +1,6 @@
-# @OpService ops
-# @Dataset data
-# @OUTPUT ImgPlus thresholdedPlus
+#@ OpService ops
+#@ Dataset data
+#@OUTPUT ImgPlus thresholdedPlus
 
 # To run this tutorial, go to 'File>Open Samples>Confocal Series' and make sure
 # that confocal-series.tif is the active image

--- a/src/main/resources/script_templates/Tutorials/Slicewise_Threshold.py
+++ b/src/main/resources/script_templates/Tutorials/Slicewise_Threshold.py
@@ -14,7 +14,7 @@ from net.imagej.axis import Axes
 # first take a look at the size and type of each dimension
 for d in range(data.numDimensions()):
 	print "axis "+str(d)+": type: "+str(data.axis(d).type())+" length: "+str(data.dimension(d))
-	
+
 xDim = data.dimensionIndex(Axes.X)
 yDim = data.dimensionIndex(Axes.Y)
 zDim = data.dimensionIndex(Axes.Z)
@@ -26,7 +26,7 @@ otsu=ops.op(Ops.Threshold.Otsu, data.getImgPlus())
 # create memory for the thresholded image
 thresholded=ops.create().img(data.getImgPlus(), BitType())
 
-# call threshold op slice-wise for the defined axes, in this case [xDim,yDim] means process the 
+# call threshold op slice-wise for the defined axes, in this case [xDim,yDim] means process the
 # first two axes (x and y)
 ops.slice(thresholded, data.getImgPlus(), otsu, [xDim,yDim])
 

--- a/src/main/resources/script_templates/Tutorials/Wiki_Jython_Tutorial_1.py
+++ b/src/main/resources/script_templates/Tutorials/Wiki_Jython_Tutorial_1.py
@@ -14,19 +14,19 @@ from random import random
 # https://imagej.nih.gov/ij/developer/api/allclasses-noframe.html
 from ij import IJ, WindowManager
 from ij.gui import GenericDialog
- 
+
 # A function is created with the def keyword.
 # This function does not need any parameters.
 def create_test_image():
     # Python uses indentation to create code blocks
- 
+
     # Local variables are assigned.
     # We can assign the same value to more than one variable.
     image_width = image_height = 512
     box_width = box_height = 128
     offset_x = offset_y = 192
     counts = 64
-    stdv = 16 
+    stdv = 16
     # The build in function int() is used to convert float to int.
     # The variable random contains a function that is called by adding parentheses.
     offset_x = int(2 * random() * offset_x)
@@ -41,7 +41,7 @@ def create_test_image():
         to_join = (prefix,) + to_concat
         # We create a generator that converts every singe entry of the tuple to a string.
         strings_to_join = (str(arg) for arg in to_join)
-        # The string ',' has a join method to concatenate values of a tuple with the string as seperator. 
+        # The string ',' has a join method to concatenate values of a tuple with the string as seperator.
         # The result is a string.
         return ','.join(strings_to_join)
     def check_existence(title):
@@ -64,7 +64,7 @@ def create_test_image():
         # We don't want to confirm when closing one of the newly created images.
         imp.changes = False
         imp.show()
- 
+
 # This function uses parameters.
 # A default value is given to the third parameter.
 def create_selection_dialog(image_titles, defaults, title='Select images for processing'):
@@ -81,13 +81,13 @@ def create_selection_dialog(image_titles, defaults, title='Select images for pro
     # _ is used as a placeholder for values we don't use.
     # The for loop is used to call gd.getNextChoiceIndex() len(defaults) times.
     return [gd.getNextChoiceIndex() for _ in defaults]
- 
+
 # It's best practice to create a function that contains the code that is executed when running the script.
 # This enables us to stop the script by just calling return.
 def run_script():
     while WindowManager.getImageCount() < 10:
         create_test_image()
-     
+
     image_titles = [WindowManager.getImage(id).getTitle() for id in WindowManager.getIDList()]
     # range(3) will create the list [0, 1, 2].
     selected_indices = create_selection_dialog(image_titles, range(3))
@@ -100,12 +100,12 @@ def run_script():
     # The previous line can be split into 2 lines:
     # selected_ids = [WindowManager.getIDList()[index] for index in selected_indices]
     # selected_imps = [WindowManager.getImage(id) for id in selected_ids]
-     
+
     for imp in selected_imps:
         # Strings can be formated using the % operator:
         # http://www.learnpython.org/en/String_Formatting
         IJ.log('The image \'%s\' has been selected.' % imp.getTitle())
- 
+
 # If a Jython script is run, the variable __name__ contains the string '__main__'.
 # If a script is loaded as module, __name__ has a different value.
 if __name__ == '__main__':

--- a/src/main/resources/script_templates/Tutorials/Wiki_Jython_Tutorial_2.py
+++ b/src/main/resources/script_templates/Tutorials/Wiki_Jython_Tutorial_2.py
@@ -8,15 +8,15 @@
 This code is part of the Jython tutorial at the ImageJ wiki.
 http://imagej.net/Jython_Scripting#Using_Scripting_Parameters
 '''
- 
+
 # The parameters in front of this comment are populated before the script runs.
 # Details on Script parameters can be found at
 # http://imagej.net/Script_parameters
- 
+
 # The module __future__ contains some useful functions:
 # https://docs.python.org/2/library/__future__.html
 from __future__ import with_statement, division
- 
+
 # It's best practice to create a function that contains the code that is executed when running the script.
 # This enables us to stop the script by just calling return.
 def run_script():
@@ -53,10 +53,10 @@ def run_script():
     filtered = fft_filter(crystal_with_noise)
     # We create a lambda function to be used as a parameter of img_calc().
     subtract = lambda values: values[0] - values[1]
-    """ This is a short form for:
-    def subtract(values):
-        return values[0] - values[1]
-    """
+    # This is a short form for:
+    # def subtract(values):
+    #   return values[0] - values[1]
+
     # The first time we call img_calc with 2 images.
     difference = img_calc(subtract, crystal, filtered, title="Difference of 2")
     difference.show()
@@ -65,11 +65,11 @@ def run_script():
     minimum.show()
     for imp in (crystal, crystal_with_noise, filtered, difference, minimum):
         IJ.run(imp, "Measure", "")
- 
+
 # Functions can be defined after they are used.
 # This is only possible if the main code is encapsulated into a function.
 # The main function has to be called at the end of the script.
- 
+
 def img_calc(func, *imps, **kwargs):
     """Runs the given function on each pixel of the given list of images.
     An additional parameter, the title of the result, is passed as keyword parameter.
@@ -87,17 +87,17 @@ def img_calc(func, *imps, **kwargs):
     from ij import ImagePlus
     from ij.process import FloatProcessor
     return ImagePlus(kwargs['title'], FloatProcessor(img_size, img_size, result))
- 
+
 def split_list(alist, wanted_parts=1):
     """Split a list to the given number of parts."""
     length = len(alist)
     # alist[a:b:step] is used to get only a subsection of the list 'alist'.
     # alist[a:b] is the same as [a:b:1].
     # '//' is an integer division.
-    # Without 'from __future__ import division' '/' would be an integer division. 
-    return [ alist[i*length // wanted_parts: (i+1)*length // wanted_parts] 
+    # Without 'from __future__ import division' '/' would be an integer division.
+    return [ alist[i*length // wanted_parts: (i+1)*length // wanted_parts]
              for i in range(wanted_parts) ]
- 
+
 def fft_filter(imp):
     """ Removing noise from an image by using a FFT filter
     This are operations copied from the ImageJ macro recorder.
@@ -122,8 +122,8 @@ def fft_filter(imp):
     imp_filtered.setTitle("Filtered " + imp.getTitle())
     imp_filtered.changes = False
     return imp_filtered
- 
- 
+
+
 # If a Jython script is run, the variable __name__ contains the string '__main__'.
 # If a script is loaded as module, __name__ has a different value.
 if __name__ == '__main__':

--- a/src/main/resources/script_templates/Tutorials/Wiki_Jython_Tutorial_2.py
+++ b/src/main/resources/script_templates/Tutorials/Wiki_Jython_Tutorial_2.py
@@ -1,7 +1,7 @@
-# @String(value='Please set some parameters.', visibility='MESSAGE') message
-# @Short(label='Image size', value=512, min=128, max=2048, stepSize=128, style="slider") img_size
-# @Double(label='Image amplitude', value=100) amplitude
-# @Short(label='Spacing', value=16, min=8) spacing
+#@ String(value='Please set some parameters.', visibility='MESSAGE') message
+#@ Short(label='Image size', value=512, min=128, max=2048, stepSize=128, style="slider") img_size
+#@ Double(label='Image amplitude', value=100) amplitude
+#@ Short(label='Spacing', value=16, min=8) spacing
 
 '''Using Scripting Parameters
 

--- a/src/main/resources/script_templates/Tutorials/Wiki_Jython_Tutorial_3.py
+++ b/src/main/resources/script_templates/Tutorials/Wiki_Jython_Tutorial_3.py
@@ -8,15 +8,15 @@
 This code is part of the Jython tutorial at the ImageJ wiki.
 http://imagej.net/Jython_Scripting#A_batch_opener_using_os.walk.28.29
 '''
- 
+
 # We do only include the module os,
 # as we can use os.path.walk()
 # to access functions of the submodule.
 import os
 from java.io import File
- 
+
 from ij import IJ
- 
+
 def batch_open_images(path, file_type=None, name_filter=None, recursive=False):
     '''Open all files in the given folder.
     :param path: The path from were to open the images. String and java.io.File are allowed.
@@ -24,10 +24,10 @@ def batch_open_images(path, file_type=None, name_filter=None, recursive=False):
     :param name_filter: Only accept files that contain the given string (default: None).
     :param recursive: Process directories recursively (default: False).
     '''
-       # Converting a File object to a string.
+    # Converting a File object to a string.
     if isinstance(path, File):
         path = path.getAbsolutePath()
- 
+
     def check_type(string):
         '''This function is used to check the file type.
         It is possible to use a single string or a list/tuple of strings as filter.
@@ -36,7 +36,7 @@ def batch_open_images(path, file_type=None, name_filter=None, recursive=False):
         '''
         if file_type:
             # The first branch is used if file_type is a list or a tuple.
-            if type(file_type) in [list, tuple]:
+            if isinstance(file_type, (list, tuple)):
                 for file_type_ in file_type:
                     if string.endswith(file_type_):
                         # Exit the function with True.
@@ -54,7 +54,7 @@ def batch_open_images(path, file_type=None, name_filter=None, recursive=False):
         # Accept all files if file_type is None.
         else:
             return True
- 
+
     def check_filter(string):
         '''This function is used to check for a given filter.
         It is possible to use a single string or a list/tuple of strings as filter.
@@ -63,7 +63,7 @@ def batch_open_images(path, file_type=None, name_filter=None, recursive=False):
         '''
         if name_filter:
             # The first branch is used if name_filter is a list or a tuple.
-            if type(name_filter) in [list, tuple]:
+            if isinstance(name_filter, (list, tuple)):
                 for name_filter_ in name_filter:
                     if name_filter_ in string:
                         # Exit the function with True.
@@ -81,7 +81,7 @@ def batch_open_images(path, file_type=None, name_filter=None, recursive=False):
         else:
         # Accept all files if name_filter is None.
             return True
- 
+
     # We collect all files to open in a list.
     path_to_images = []
     # Replacing some abbreviations (e.g. $HOME on Linux).
@@ -122,7 +122,7 @@ def batch_open_images(path, file_type=None, name_filter=None, recursive=False):
         if imp:
             images.append(imp)
     return images
- 
+
 def split_string(input_string):
     '''Split a string to a list and strip it
     :param input_string: A string that contains semicolons as separators.
@@ -131,10 +131,9 @@ def split_string(input_string):
     # Remove whitespace at the beginning and end of each string
     strings_striped = [string.strip() for string in string_splitted]
     return strings_striped
- 
+
 if __name__ == '__main__':
-    '''Run the batch_open_images() function using the Scripting Parameters.
-    '''
+    # Run the batch_open_images() function using the Scripting Parameters.
     images = batch_open_images(import_dir,
                                split_string(file_types),
                                split_string(filters),

--- a/src/main/resources/script_templates/Tutorials/Wiki_Jython_Tutorial_3.py
+++ b/src/main/resources/script_templates/Tutorials/Wiki_Jython_Tutorial_3.py
@@ -1,7 +1,7 @@
-# @File(label='Choose a directory', style='directory') import_dir
-# @String(label='File types', value='tif;png') file_types
-# @String(label='Filter', value='') filters
-# @Boolean(label='Recursive search', value=True) do_recursive
+#@ File(label='Choose a directory', style='directory') import_dir
+#@ String(label='File types', value='tif;png') file_types
+#@ String(label='Filter', value='') filters
+#@ Boolean(label='Recursive search', value=True) do_recursive
 
 '''A batch opener using os.walk()
 

--- a/src/test/java/net/imagej/scripting/ImageJ2ScriptTest.java
+++ b/src/test/java/net/imagej/scripting/ImageJ2ScriptTest.java
@@ -18,7 +18,6 @@ import javax.script.ScriptException;
 
 import net.imagej.Dataset;
 
-import org.junit.Assert;
 import org.junit.Test;
 import org.scijava.plugin.Parameter;
 import org.scijava.script.ScriptModule;


### PR DESCRIPTION
This PR adds a few code style fixes:

* Consistent use of language-agnostic script parameter syntax in template scripts
* Remove trailing whitespace
* Remove unused imports
* Replace Python `type()` by `isinstance()`