### PR TITLE
Correct if __name__ == '__main__'

### DIFF
--- a/src/main/resources/script_templates/Tutorials/Wiki_Jython_Tutorial_1.py
+++ b/src/main/resources/script_templates/Tutorials/Wiki_Jython_Tutorial_1.py
@@ -108,5 +108,5 @@ def run_script():
 
 # If a Jython script is run, the variable __name__ contains the string '__main__'.
 # If a script is loaded as module, __name__ has a different value.
-if __name__ == '__main__':
+if __name__ in ['__builtin__','__main__']:
     run_script()

--- a/src/main/resources/script_templates/Tutorials/Wiki_Jython_Tutorial_2.py
+++ b/src/main/resources/script_templates/Tutorials/Wiki_Jython_Tutorial_2.py
@@ -126,5 +126,5 @@ def fft_filter(imp):
 
 # If a Jython script is run, the variable __name__ contains the string '__main__'.
 # If a script is loaded as module, __name__ has a different value.
-if __name__ == '__main__':
+if __name__ in ['__builtin__','__main__']:
     run_script()

--- a/src/main/resources/script_templates/Tutorials/Wiki_Jython_Tutorial_3.py
+++ b/src/main/resources/script_templates/Tutorials/Wiki_Jython_Tutorial_3.py
@@ -132,7 +132,7 @@ def split_string(input_string):
     strings_striped = [string.strip() for string in string_splitted]
     return strings_striped
 
-if __name__ == '__main__':
+if __name__ in ['__builtin__','__main__']:
     # Run the batch_open_images() function using the Scripting Parameters.
     images = batch_open_images(import_dir,
                                split_string(file_types),


### PR DESCRIPTION
Contrary to a normal python installation, __name__ is not always equal to __main__ but instead __builtin__.
This workaround was reported [here ](http://forum.imagej.net/t/jython-isssue-with-if---name-----main--/5544/2?u=lthomas) and [there](http://forum.imagej.net/t/script-editor-error-when-working-with-python-scripts/5893/6?u=lthomas). 