### PR TITLE
Fix convolve/deconvolve signatures

### DIFF
--- a/src/main/resources/script_templates/Deconvolution/DeconWithChirpImg.groovy
+++ b/src/main/resources/script_templates/Deconvolution/DeconWithChirpImg.groovy
@@ -40,7 +40,7 @@ psf=IJ.getImage()
 psf=ImageJFunctions.wrapFloat(psf)
 
 // convolve chirp and psf
-convolved=ops.filter().convolve(exponentialChirp, psf)
+convolved=ops.filter().convolve(ops.create().img(exponentialChirp), exponentialChirp, psf)
 ui.show("convolved", convolved)
 
 plotProfile()
@@ -52,18 +52,18 @@ ui.show("noisy", noisy)
 plotProfile()
 
 // deconvolve
-deconvolved=ops.deconvolve().richardsonLucy(noisy, psf,10)
+deconvolved=ops.deconvolve().richardsonLucy(ops.create().img(noisy), noisy, psf,10)
 ui.show("deconvolved", deconvolved)
 plotProfile()
 
-deconvolved_accelerated=ops.deconvolve().richardsonLucy(noisy, psf, null, null, null, null, null, 10, false, true)
+deconvolved_accelerated=ops.deconvolve().richardsonLucy(ops.create().img(noisy), noisy, psf, null, null, null, null, null, 10, false, true)
 ui.show("deconvolved accelerated", deconvolved_accelerated)
 plotProfile()
 
-deconvolved_rltv=ops.deconvolve().richardsonLucyTV(noisy, psf, 10, 0.01)
+deconvolved_rltv=ops.deconvolve().richardsonLucyTV(ops.create().img(noisy), noisy, psf, 10, 0.01)
 ui.show("deconvolved rltv", deconvolved_rltv)
 plotProfile()
 
-deconvolved_rltv_accelerated=ops.deconvolve().richardsonLucyTV(noisy, psf, null, null, null, null, null, 10, false, true, 0.01)
+deconvolved_rltv_accelerated=ops.deconvolve().richardsonLucyTV(ops.create().img(noisy), noisy, psf, null, null, null, null, null, 10, false, true, 0.01)
 ui.show("deconvolved rltv accelerated", deconvolved_rltv_accelerated)
 plotProfile()

--- a/src/main/resources/script_templates/Deconvolution/DeconWithGaussian.py
+++ b/src/main/resources/script_templates/Deconvolution/DeconWithGaussian.py
@@ -18,4 +18,5 @@ elif img_float.numDimensions()==2:
 ui.show(psf)
 
 # deconvolve
-deconvolved=ops.deconvolve().richardsonLucyTV(img_float, psf, numIterations, 0.01)
+out=ops.create().img(img_float);
+deconvolved=ops.deconvolve().richardsonLucyTV(out,img_float, psf, numIterations, 0.01)

--- a/src/main/resources/script_templates/Deconvolution/DeconWithGrid.groovy
+++ b/src/main/resources/script_templates/Deconvolution/DeconWithGrid.groovy
@@ -6,7 +6,7 @@
 import net.imglib2.type.numeric.real.FloatType;
 import net.imagej.ops.Op
 import net.imglib2.outofbounds.OutOfBoundsConstantValueFactory
-import net.imagej.ops.deconvolve.RichardsonLucyF
+import net.imagej.ops.deconvolve.PadAndRichardsonLucy
 import net.imglib2.util.Util
 
 // create the sample image
@@ -24,22 +24,23 @@ ops.image().equation(kernel_small, "p[0]")
 ops.image().equation(kernel_big, "p[0]")
 
 // convolve with large and small kernel
+//convolved_small = ops.create().img(base, new FloatType())
 convolved_small = ops.filter().convolve(base, kernel_small)
-convolved_big = ops.filter().convolve(base, kernel_big)
+convolved_big = ops.filter().convolve(ops.create().img(base), base, kernel_big)
 
 ui.show(convolved_small);
 ui.show(convolved_big);
 
-base_deconvolved = ops.run(RichardsonLucyF.class, convolved_small, kernel_small, null, new OutOfBoundsConstantValueFactory<>(Util.getTypeFromInterval(kernel_small).createVariable()), 10)
+base_deconvolved = ops.run(PadAndRichardsonLucy.class, ops.create().img(convolved_small), convolved_small, kernel_small, null, new OutOfBoundsConstantValueFactory<>(Util.getTypeFromInterval(kernel_small).createVariable()), 10)
 
 // 50 iterations richardson lucy
-base_deconvolved_big = ops.run(RichardsonLucyF.class, convolved_big, kernel_big, 50);
+base_deconvolved_big = ops.run(PadAndRichardsonLucy.class, ops.create().img(convolved_big), convolved_big, kernel_big, 50);
 
 // 50 iterations non-circulant richardson lucy
-base_deconvolved_big_noncirc = ops.run(RichardsonLucyF.class, convolved_big, kernel_big, null, null,null, null, null,50,true,false );
+base_deconvolved_big_noncirc = ops.run(PadAndRichardsonLucy.class, ops.create().img(convolved_big), convolved_big, kernel_big, null, null,null, null, null,50,true,false );
 
 // 50 iterations non-circulant accelerated richardson lucy
-base_deconvolved_big_acc_noncirc = ops.run(RichardsonLucyF.class, convolved_big, kernel_big, null, null,null, null, null, 50, true, true)
+base_deconvolved_big_acc_noncirc = ops.run(PadAndRichardsonLucy.class, ops.create().img(convolved_big),convolved_big, kernel_big, null, null,null, null, null, 50, true, true)
 
 ui.show("RL",base_deconvolved_big)
 ui.show("RLNon-Circ",base_deconvolved_big_noncirc)

--- a/src/main/resources/script_templates/Deconvolution/DeconWithTheoreticalPSF.py
+++ b/src/main/resources/script_templates/Deconvolution/DeconWithTheoreticalPSF.py
@@ -41,5 +41,5 @@ depth = 0;
 psf = ops.create().kernelDiffraction(psfSize, numericalAperture, wavelength,
 				riSample, riImmersion, xySpacing, zSpacing, depth, FloatType());
 
-deconvolved = ops.deconvolve().richardsonLucy(imgF, psf, borderSize, None,
+deconvolved = ops.deconvolve().richardsonLucy(ops.create().img(imgF), imgF, psf, borderSize, None,
 					None, None, None, numIterations, True, True);

--- a/src/main/resources/script_templates/Deconvolution/ExtractPSF.py
+++ b/src/main/resources/script_templates/Deconvolution/ExtractPSF.py
@@ -56,4 +56,4 @@ beads32=ops.convert().float32(beads)
 points32=ops.convert().float32(points)
 
 # use "PSF Distilling" (reverse deconvolution) to solve for PSF
-psf=ops.deconvolve().richardsonLucy(beads32, points32, None, None, None, None, None, 30, False, True)
+psf=ops.deconvolve().richardsonLucy(ops.create().img(beads32), beads32, points32, None, None, None, None, None, 30, False, True)

--- a/src/main/resources/script_templates/Tutorials/Create_and_Convolve_Points.py
+++ b/src/main/resources/script_templates/Tutorials/Create_and_Convolve_Points.py
@@ -37,7 +37,7 @@ phantom.setName("phantom")
 psf=ops.create().kernelGauss([5, 5, 5])
 
 # convolve psf with phantom
-convolved=ops.filter().convolve(phantom, psf)
+convolved=ops.filter().convolve(ops.create().img(phantom), phantom, psf)
 
 # make convolved an ImgPlus
 convolved=ops.create().imgPlus(convolved);

--- a/src/main/resources/script_templates/Tutorials/Ops_Threshold_IJ1_Analyze.py
+++ b/src/main/resources/script_templates/Tutorials/Ops_Threshold_IJ1_Analyze.py
@@ -16,7 +16,7 @@ from ij import IJ
 # create a log kernel
 logKernel=ops.create().kernelLog(inputData.numDimensions(), sigma);
 
-logFiltered=ops.filter().convolve(inputData, logKernel)
+logFiltered=ops.filter().convolve(ops.create().img(inputData), inputData, logKernel)
 
 # otsu threshold and display
 thresholded = ops.threshold().otsu(logFiltered)

--- a/src/main/resources/script_templates/Tutorials/Ops_Threshold_Measure.py
+++ b/src/main/resources/script_templates/Tutorials/Ops_Threshold_Measure.py
@@ -14,11 +14,14 @@
 from net.imglib2.algorithm.labeling.ConnectedComponents import StructuringElement
 from net.imglib2.roi import Regions;
 from net.imglib2.roi.labeling import LabelRegions;
+from net.imglib2.type.numeric.real import FloatType;
 
 # create a log kernel
 logKernel=ops.create().kernelLog(inputData.numDimensions(), sigma);
 
-logFiltered=ops.filter().convolve(inputData, logKernel)
+logFiltered=ops.filter().convolve(ops.create().img(inputData, FloatType()), inputData, logKernel)
+
+
 
 # otsu threshold and display
 thresholded = ops.threshold().otsu(logFiltered)


### PR DESCRIPTION
This pull request changes the convolve and deconvolve calls to computers.  This [imagej-ops fix](https://github.com/imagej/imagej-ops/pull/611) is also needed to fix all the errors in these scripts. 

Even after these fixes I am still seeing errors in ```ImageJ2ScriptTest.testFastThresholdScript```, ```ImageJ2ScriptTest.testSubtractFirstFrameScript``` and ```ImageJ2ScriptTest.testThresholdScript``` which seem to be related to a conversion issue.   